### PR TITLE
Disassembler: Break Out On Jumpdest, SWAPx, etc

### DIFF
--- a/src/disassemble.c
+++ b/src/disassemble.c
@@ -147,6 +147,13 @@ void disassembleNextOp(const char **iter) {
         statement_append(&op_statement, ')');
     }
     statement_stack_append(&stack, op_statement);
+    if (retCount[op] != 1) {
+        for (size_t i = 0; i < stack.num_statements; i++) {
+            puts(stack.statements[i].schars);
+            free(stack.statements[i].schars);
+        }
+        stack.num_statements = 0;
+    }
     pc++;
 }
 


### PR DESCRIPTION

The prior behavior is not ideal when encountering JUMPDEST and SWAP; it would treat those as arguments to subsequent ops even though they do not push to the stack.
This change improves legibility of the disassembly output in several circumstances, especially for disassembled Solidity.
#### Changes
Dump statement stack when encountering an op that does not push one value onto the stack.