### PR TITLE
Update Readme Supported Ops According To src/evm.c

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ If you find a bug that disrupts you, please file an issue with its impact to you
 | SDIV | ✅ |✅ |
 | MOD | ✅ |✅ |
 | SMOD | ✅ |✅ |
-| ADDMOD | ✅ |❓ |
+| ADDMOD | ✅ | ❌ |
 | MULMOD | ✅ |✅ |
 | EXP | ✅ |✅ |
 | SIGNEXTEND | ✅ |✅ |
@@ -195,7 +195,7 @@ If you find a bug that disrupts you, please file an issue with its impact to you
 | SHA3 | ✅ |✅ |
 | ADDRESS | ✅ |✅ |
 | BALANCE | ✅ |✅ |
-| ORIGIN | ✅ |❓ |
+| ORIGIN | ✅ | ❌ |
 | CALLER | ✅ |✅ |
 | CALLVALUE | ✅ |✅ |
 | CALLDATALOAD | ✅ |✅ |
@@ -203,21 +203,21 @@ If you find a bug that disrupts you, please file an issue with its impact to you
 | CALLDATACOPY | ✅ |✅ |
 | CODESIZE | ✅ |✅ |
 | CODECOPY | ✅ |✅ |
-| GASPRICE | ✅ |❓ |
+| GASPRICE | ✅ | ❌ |
 | EXTCODESIZE | ✅ |✅ |
 | EXTCODECOPY | ✅ |✅ |
 | RETURNDATASIZE | ✅ |✅ |
 | RETURNDATACOPY | ✅ |✅ |
-| EXTCODEHASH | ✅ |❓ |
-| BLOCKHASH | ✅ |❓ |
-| COINBASE | ✅ |❓ |
+| EXTCODEHASH | ✅ | ❌ |
+| BLOCKHASH | ✅ | ❌ |
+| COINBASE | ✅ | ❌ |
 | TIMESTAMP | ✅ |❓ |
 | NUMBER | ✅ |❓ |
-| DIFFICULTY | ✅ |❓ |
-| GASLIMIT | ✅ |❓ |
-| CHAINID | ✅ |❓ |
+| DIFFICULTY | ✅ | ❌ |
+| GASLIMIT | ✅ | ❌ |
+| CHAINID | ✅ | ❌ |
 | SELFBALANCE | ✅ |✅ |
-| BASEFEE | ✅ |❓ |
+| BASEFEE | ✅ | ❌ |
 | POP | ✅ |❓ |
 | MLOAD | ✅ |❓ |
 | MSTORE | ✅ |✅ |
@@ -230,9 +230,9 @@ If you find a bug that disrupts you, please file an issue with its impact to you
 | MSIZE | ✅ |✅ |
 | GAS | ✅ |✅ |
 | JUMPDEST | ✅ |✅ |
-| TLOAD | ✅ |❓ |
-| TSTORE | ✅ |❓ |
-| MCOPY | ✅ |❓ |
+| TLOAD | ✅ | ❌ |
+| TSTORE | ✅ | ❌ |
+| MCOPY | ✅ | ❌ |
 | PUSH0 | ✅ |✅ |
 | PUSH1 | ✅ |✅ |
 | PUSH2 | ✅ |✅ |
@@ -305,15 +305,15 @@ If you find a bug that disrupts you, please file an issue with its impact to you
 | LOG4 | ✅ |✅ |
 | CREATE | ✅ |❓ |
 | CALL | ✅ |✅ |
-| CALLCODE | ✅ |❓ |
+| CALLCODE | ✅ | ❌ |
 | RETURN | ✅ |✅ |
 | DELEGATECALL | ✅ |✅ |
 | CREATE2 | ✅ |❓ |
-| AUTH | ✅ |❓ |
-| AUTHCALL | ✅ |❓ |
+| AUTH | ✅ | ❌ |
+| AUTHCALL | ✅ | ❌ |
 | STATICCALL | ✅ |✅ |
 | REVERT | ✅ |✅ |
-| INVALID | ✅ |❓ |
+| INVALID | ✅ | ❌ |
 | SELFDESTRUCT | ✅ |❓ |
 # Contributing
 Please use camelCase for methods and variables but snake\_case for types.

--- a/make/ops.sh
+++ b/make/ops.sh
@@ -4,5 +4,5 @@ for op in $( bin/ops ) ; do
     [[ "$op" == *"ASSERT_"* ]] && continue
     echo -n "| $op | "
     grep $op src/ops.c >/dev/null && echo -n "✅ |" || echo -n "❓ | "
-    grep $op tst/evm.c >/dev/null && echo "✅ |" || echo "❓ |"
+    grep $op tst/evm.c >/dev/null && echo "✅ |" || (grep $op src/evm.c >/dev/null && echo "❓ |" || echo " ❌ |")
 done


### PR DESCRIPTION

If an opcode is in src/evm.c it might be supported.
Otherwise it certainly is not.
#### Changes
Improve opcode support table by distinguishing opcodes that are surely not supported with a red X.