### PR TITLE
Dio: Contract Creator

### DIFF
--- a/include/address.h
+++ b/include/address.h
@@ -9,7 +9,7 @@ typedef struct address {
     uint8_t address[20];
 } __attribute__((__packed__)) address_t;
 
-#define AddressCopy(dst, src) memcpy(dst.address, src.address, 20)
+#define AddressCopy(dst, src) memcpy((dst).address, (src).address, 20)
 
 static inline int AddressEqual(const address_t *expected, const address_t *actual) {
     for (int i = 0; i < 20; i ++) {

--- a/src/dio.c
+++ b/src/dio.c
@@ -543,7 +543,7 @@ static address_t *jsonReadAddress(const char **iter) {
     address_t *address = malloc(sizeof(address_t));
     for (unsigned int i = 0; i < 20; i++) {
         address->address[i] = hexString16ToUint8(*iter);
-        (*iter) += 2;
+        *iter += 2;
     }
     return address;
 }

--- a/src/dio.c
+++ b/src/dio.c
@@ -115,6 +115,7 @@ typedef struct entry {
     address_t *address;
     val_t balance;
     uint64_t nonce;
+    address_t *creator;
     data_t initCode;
     data_t code;
     storageEntry_t *storage;
@@ -386,8 +387,11 @@ static void applyEntry(entry_t *entry) {
         input.content = (uint8_t *)content;
         input.size /= 2;
 
-        // TODO support these parameters
         address_t from;
+        if (entry->creator) {
+            AddressCopy(from, *entry->creator);
+        }
+        // TODO support these parameters
         uint64_t gas = 0xffffffffffffffff;
         val_t value;
         value[0] = 0;
@@ -398,8 +402,11 @@ static void applyEntry(entry_t *entry) {
         result_t constructResult = evmConstruct(from, *entry->address, gas, value, input);
         verifyConstructResult(&constructResult, entry);
     } else if (entry->initCode.size) {
-        // TODO support these parameters
         address_t from;
+        if (entry->creator) {
+            AddressCopy(from, *entry->creator);
+        }
+        // TODO support these parameters
         uint64_t gas = 0xffffffffffffffff;
         val_t value;
         value[0] = 0;
@@ -530,6 +537,24 @@ static void jsonScanAccountLogs(const char **iter, logsEntry_t **prev) {
     jsonSkipExpectedChar(iter, ']');
 }
 
+static address_t *jsonReadAddress(const char **iter) {
+    jsonSkipExpectedChar(iter, '0');
+    jsonSkipExpectedChar(iter, 'x');
+    address_t *address = malloc(sizeof(address_t));
+    for (unsigned int i = 0; i < 20; i++) {
+        address->address[i] = hexString16ToUint8(*iter);
+        (*iter) += 2;
+    }
+    return address;
+}
+
+static address_t *jsonReadAddressString(const char **iter) {
+    jsonSkipExpectedChar(iter, '"');
+    address_t *address = jsonReadAddress(iter);
+    jsonSkipExpectedChar(iter, '"');
+    return address;
+}
+
 static void jsonScanEntry(const char **iter) {
     entry_t entry;
     bzero(&entry, sizeof(entry_t));
@@ -541,15 +566,7 @@ static void jsonScanEntry(const char **iter) {
         switch(*(uint32_t *)heading) {
             case 'rdda':
                 // address
-                jsonSkipExpectedChar(iter, '"');
-                jsonSkipExpectedChar(iter, '0');
-                jsonSkipExpectedChar(iter, 'x');
-                entry.address = malloc(sizeof(address_t));
-                for (unsigned int i = 0; i < 20; i++) {
-                    entry.address->address[i] = hexString16ToUint8(*iter);
-                    (*iter) += 2;
-                }
-                jsonSkipExpectedChar(iter, '"');
+                entry.address = jsonReadAddressString(iter);
                 break;
             case 'alab':
                 // balance
@@ -580,6 +597,10 @@ static void jsonScanEntry(const char **iter) {
                     (*iter)++;
                 }
                 jsonSkipExpectedChar(iter, '"');
+                break;
+            case 'aerc':
+                // creator
+                entry.creator = jsonReadAddressString(iter);
                 break;
             case 'tini':
                 // init, initcode, initCode
@@ -789,16 +810,10 @@ static void jsonScanEntry(const char **iter) {
                                     }
                                 } else if (testHeadingLen == 2 && *testHeading == 't') {
                                     // to
-                                    jsonSkipExpectedChar(&testValue, '0');
-                                    jsonSkipExpectedChar(&testValue, 'x');
                                     if (test->to) {
                                         free(test->to);
                                     }
-                                    test->to = malloc(sizeof(address_t));
-                                    for (unsigned int i = 0; i < 20; i++) {
-                                        test->to->address[i] = hexString16ToUint8(testValue);
-                                        testValue += 2;
-                                    }
+                                    test->to = jsonReadAddress(&testValue);
                                 } else if (testHeadingLen == 7 && *testHeading == 'g') {
                                     // gasUsed
                                     jsonSkipExpectedChar(&testValue, '0');

--- a/src/disassemble.c
+++ b/src/disassemble.c
@@ -21,7 +21,7 @@ static void disassembleWaste(const char **iter) {
         (*iter)++;
     }
     if (**iter == '0' && *(*iter + 1) == 'x') {
-        (*iter) += 2;
+        *iter += 2;
         disassembleWaste(iter);
     }
 }

--- a/src/scan.c
+++ b/src/scan.c
@@ -164,7 +164,7 @@ static int parseNegative(const char **iter) {
 
 op_t parseConstant(const char **iter) {
     if (isHexConstantPrefix(*iter)) {
-        (*iter) += 2;
+        *iter += 2;
         return parseHex(iter);
     } else {
         int negative = 0;
@@ -249,7 +249,7 @@ static void scanDataSection(const char **iter) {
     if (**iter == '"') {
         // TODO parse ascii
     } else if (isHexConstantPrefix(*iter)) {
-        (*iter) += 2;
+        *iter += 2;
         parseHex(iter);
     }
     scanstackPushLabel(start, end - start, CODECOPY);


### PR DESCRIPTION

It is now possible to specify msg.sender (CALLER) for `initcode` and `construct` in `-w` (dio).
#### Changes
* create jsonReadAddress and jsonReadAddressString to share address parsing logic
* use jsonReadAddressString to parse creator
* use creator for both construct and initcode create