### PR TITLE
Universal Runtime Constructor

### DIFF
--- a/evm.c
+++ b/evm.c
@@ -79,7 +79,7 @@ static void assemble(const char *contents) {
             }
         }
     } else if (wrapUniversalConstructor) {
-        // 600b380380600b3d393df3
+        // 600b380380600b3d393df3<>
         programStart -= 4;
         *((uint32_t *)programStart) = 0xf33d393d;
         programStart -= 4;


### PR DESCRIPTION
The universal runtime constructor is a constructor designed for portability and standardization.
For example, it is recommended by the [draft ERC 8152](https://github.com/ethereum/ERCs/pull/1521) as a way to make delegates constructed with create2 addressable.
This constructor is not as efficient as the minimum constructors I already support, but works for code of any size.
#### Changes
* adds support for universal runtime constructor via -C