### PR TITLE
fix: handle division by zero

### DIFF
--- a/src/evm.c
+++ b/src/evm.c
@@ -936,10 +936,11 @@ static result_t doCall(context_t *callContext) {
                 mul256(callContext->top, callContext->top - 1, callContext->top - 1);
                 break;
             case DIV:
-                divmod256(callContext->top, callContext->top - 1, callContext->top - 1, callContext->top + 1);
+                if (!zero256(callContext->top - 1))
+                    divmod256(callContext->top, callContext->top - 1, callContext->top - 1, callContext->top + 1);
                 break;
             case SDIV:
-                {
+                if (!zero256(callContext->top - 1)) {
                     bool negative = false;
                     uint256_t zero;
                     clear256(&zero);
@@ -958,10 +959,11 @@ static result_t doCall(context_t *callContext) {
                 }
                 break;
             case MOD:
-                divmod256(callContext->top, callContext->top - 1, callContext->top + 1, callContext->top - 1);
+                if (!zero256(callContext->top - 1))
+                    divmod256(callContext->top, callContext->top - 1, callContext->top + 1, callContext->top - 1);
                 break;
             case SMOD:
-                {
+                if (!zero256(callContext->top - 1)) {
                     bool negative = false;
                     uint256_t zero;
                     clear256(&zero);

--- a/tst/evm.c
+++ b/tst/evm.c
@@ -495,6 +495,36 @@ void test_sgtslt() {
     evmFinalize();
 }
 
+void test_div_zero() {
+    evmInit();
+
+    address_t from = AddressFromHex42("0x4a6f6B9fF1fc974096f9063a45Fd12bD5B928AD1");
+    uint64_t gas = 0x16838;
+    val_t value = {0, 0, 0};
+    data_t input;
+
+    op_t program[] = {
+        PUSH0, PUSH1, 5, DIV,    MSIZE, MSTORE,
+        PUSH0, PUSH1, 5, SDIV,   MSIZE, MSTORE,
+        PUSH0, PUSH1, 5, MOD,    MSIZE, MSTORE,
+        PUSH0, PUSH1, 5, SMOD,   MSIZE, MSTORE,
+        PUSH0, PUSH1, 3, PUSH1, 5, ADDMOD, MSIZE, MSTORE,
+        PUSH0, PUSH1, 3, PUSH1, 5, MULMOD, MSIZE, MSTORE,
+        MSIZE, PUSH0, RETURN,
+    };
+    input.size = sizeof(program);
+    input.content = program;
+
+    result_t result = txCreate(from, gas, value, input);
+    assert(result.returnData.size == 192);
+    assert(result.gasRemaining == 0);
+    for (size_t i = 0; i < 192; i++) {
+        assert(result.returnData.content[i] == 0);
+    }
+
+    evmFinalize();
+}
+
 void test_sdiv() {
     evmInit();
 
@@ -2497,6 +2527,7 @@ int main() {
     test_clz();
     test_xorSwap();
     test_sgtslt();
+    test_div_zero();
     test_sdiv();
     test_smod();
     test_addmod();


### PR DESCRIPTION
Per EVM spec, DIV/MOD/SDIV/SMOD with a zero divisor must return 0. Previously `divmod256` was called unconditionally, causing an infinite loop in the shift-and-subtract implementation.

#### Changes
* Guard DIV, SDIV, MOD, SMOD with `zero256` check; skip `divmod256` when divisor is zero (result slot already holds 0)
* Add `test_div_zero` covering all six division/modulo opcodes (DIV, SDIV, MOD, SMOD, ADDMOD, MULMOD) with zero divisor/modulus
